### PR TITLE
fix tsc error with script directory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,7 @@
   },
   "exclude": [
     "node_modules",
+    "script",
     "**/*.spec.ts",
     "**/stubs",
     "**/__mocks__"


### PR DESCRIPTION
when we run `tsc` we get the following error printed

```
error TS6059: File '/Users/opeer/repo/sbgsso/idp-hook-updates/script/ManageDuoAdminAPI.ts' is not under 'rootDir' '/Users/opeer/repo/sbgsso/idp-hook-updates/src'. 'rootDir' is expected to contain all source files.


Found 1 error.
```

This PR fixes it.
