### PR TITLE
increase aws lambda timeout

### DIFF
--- a/common/cloud/aws/terraform/modules/idp-hook-updates/variables.tf
+++ b/common/cloud/aws/terraform/modules/idp-hook-updates/variables.tf
@@ -24,5 +24,5 @@ variable "lambda_handler" {
 
 variable "lambda_timeout" {
   type    = number
-  default = 3
+  default = 10
 }


### PR DESCRIPTION
Adding a user to a group timed out in the middle of the operation.
https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/lambda/ci-okta-duo-idp-hook-updates;stream=2020/03/17/[$LATEST]a1c6447208de46cb918a7942e681ad60;start=2020-03-16T16:32:43Z

Is 10 seconds enough if we get a few events in the request?
Maybe we should go to 29 like we do in Auth0
