### PR TITLE
Properly escape parens in input to Duo

### DIFF
--- a/common/mfa/duo/src/DuoAdminAPI.ts
+++ b/common/mfa/duo/src/DuoAdminAPI.ts
@@ -33,6 +33,15 @@ export class DuoAdminAPI {
     };
   }
 
+  encodeForDuo(input: string) {
+    return encodeURIComponent(input)
+      .replace(/!/g, '%21')
+      .replace(/'/g, '%27')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/\*/g, '%2A');
+  }
+
   /**
    * Convert a map of parameters to a form encoded string, sorted by parameter names
    * @param params parameter map to convert
@@ -43,7 +52,7 @@ export class DuoAdminAPI {
         .sortBy(0)
         .fromPairs()
         .map(
-            (val, key) => `${encodeURIComponent(key)}=${encodeURIComponent(val)}`,
+            (val, key) => `${this.encodeForDuo(key)}=${this.encodeForDuo(val)}`,
         )
         .join('&')
         .value();

--- a/common/mfa/duo/src/DuoUpdateRecipient.ts
+++ b/common/mfa/duo/src/DuoUpdateRecipient.ts
@@ -80,7 +80,7 @@ export class DuoUpdateRecipient implements UpdateRecipient {
       }));
 
     return this.axios
-      .get(`/users?username=${encodeURIComponent(username)}`, {
+      .get(`/users?username=${this.duoAdminApi.encodeForDuo(username)}`, {
         headers: {
           Date: date,
           Authorization: `Basic ${signature}`,

--- a/common/mfa/duo/src/__tests__/DuoAdminAPI.spec.ts
+++ b/common/mfa/duo/src/__tests__/DuoAdminAPI.spec.ts
@@ -182,3 +182,14 @@ describe('createWebSdk', () => {
     });
   });
 });
+
+describe('#encodeForDuo', () => {
+  it('should properly encode special characters', () => {
+    const adminAPI = new DuoAdminAPI(integrationKey, signatureSecret, duoAdminApiHost);
+    expect(adminAPI.encodeForDuo('test=escape')).toEqual('test%3Descape');
+    expect(adminAPI.encodeForDuo('!test!')).toEqual('%21test%21');
+    expect(adminAPI.encodeForDuo('\'test\'')).toEqual('%27test%27');
+    expect(adminAPI.encodeForDuo('(test)')).toEqual('%28test%29');
+    expect(adminAPI.encodeForDuo('test**')).toEqual('test%2A%2A');
+  });
+});


### PR DESCRIPTION
Closes #71 

Duo expects special characters to be encoded as well, see https://github.com/duosecurity/duo_api_nodejs/blob/master/lib/duo_sig.js#L48
There is a bug in Duo code above since they only replace the first occurrence of the special character.

