### PR TITLE
Do not add a user to groups in 'create user' flow since Okta sends these as separate events

### DIFF
--- a/okta/common/src/OktaHooks.ts
+++ b/okta/common/src/OktaHooks.ts
@@ -62,16 +62,7 @@ export class OktaHooks implements UpdateInitiator {
 
       if (event.eventType === 'user.lifecycle.create') {
         const userToCreate: InitiatorUser = await this.fetchUser(userTarget.alternateId);
-        // create the user
-        const recipientUserId = await this.updateRecipient.create(userToCreate);
-        // add the user groups to the user
-        const userGroups = await this.oktaService.getUserGroups(userToCreate.id);
-        return Promise.all(
-          _.chain(userGroups)
-            .filter({ type: 'OKTA_GROUP' })
-            .map(group => group.profile.name)
-            .map(groupName => this.updateRecipient.addUserToGroupByUserId(recipientUserId, groupName, true))
-            .value());
+        return this.updateRecipient.create(userToCreate);
       }
 
       const recipientUser = await this.updateRecipient.getUser(userTarget.alternateId);

--- a/okta/common/src/OktaService.ts
+++ b/okta/common/src/OktaService.ts
@@ -105,19 +105,6 @@ export class OktaService {
       .catch(Helper.logError);
   }
 
-  async getUserGroups(userId: string): Promise<any> {
-    const apiKey = this.secretsService.initiatorApiKey;
-
-    return this.axios
-      .get(`/users/${userId}/groups`, {
-        headers: {
-          Authorization: `SSWS ${apiKey}`,
-        },
-      })
-      .then(res => res.data)
-      .catch(Helper.logError);
-  }
-
   async getEventHooks(): Promise<any> {
     const apiKey = this.secretsService.initiatorApiKey;
 

--- a/okta/common/src/__tests__/OktaService.spec.ts
+++ b/okta/common/src/__tests__/OktaService.spec.ts
@@ -93,32 +93,6 @@ describe('with OKTA_ENDPOINT', () => {
     expect(getFn).toHaveBeenCalledWith(`/users/${userId}`, { headers: { Authorization: `SSWS ${secretsServiceStub.initiatorApiKey}` } });
   });
 
-  it('should return the user groups from Okta', async () => {
-    const userGroups = [
-      {
-        type: 'BUILT_IN',
-        profile: {
-          name: 'Everyone',
-        },
-      },
-      {
-        type: 'OKTA_GROUP',
-        profile: {
-          name: 'Test',
-        },
-      },
-    ];
-    getFn = jest.fn(() => Promise.resolve({ data: userGroups }));
-    // @ts-ignore
-    axios.create = jest.fn(() => ({
-      get: getFn,
-    }));
-    const oktaService = new OktaService(secretsServiceStub);
-    const retrievedUserGroups = await oktaService.getUserGroups(userId);
-    expect(retrievedUserGroups).toEqual(userGroups);
-    expect(getFn).toHaveBeenCalledWith(`/users/${userId}/groups`, { headers: { Authorization: `SSWS ${secretsServiceStub.initiatorApiKey}` } });
-  });
-
   it('should log and throw error when the call fails', async (done) => {
     getFn = jest.fn(() => Promise.reject(axiosError));
     // @ts-ignore


### PR DESCRIPTION
Closes #75 

This PR changes the code so that "create user" does not add the user to the groups. Okta sends separate events for "create user" and for "associate user to group". See #75 for more details.