### PR TITLE
Increase group creation timeout

### DIFF
--- a/okta/duo/spec/src/__tests__/ci.spec.ts
+++ b/okta/duo/spec/src/__tests__/ci.spec.ts
@@ -12,7 +12,7 @@ const DUO_HOST = process.env.DUO_HOST;
 const CI_USER = process.env.CI_USER;
 
 const SPEC_TIMEOUT = 60 * 1000;
-const CREATE_GROUP_TIMEOUT = 10 * 1000;
+const CREATE_GROUP_TIMEOUT = 60 * 1000;
 
 let oktaClient: any;
 let duoClient: any;


### PR DESCRIPTION
CI Failed since group creation only succeeded on the 3rd attempt.
Meanwhile the `beforeAll` method timed out.
https://github.com/cisco-sbgidm/idp-hook-updates/actions/runs/121533377

Increasing the timeout threshold.
