### PR TITLE
Ignore lodash vulnerability advisory 1523 since it looks like it won't be fixed

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,4 +23,4 @@ jobs:
           node-version: 12.x
       - name: 'Run Audit'
         run: |
-          yarn audit
+          yarn run improved-yarn-audit --exclude 1523 --ignore-dev-deps

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "tslint-config-airbnb": "^5.11.2",
     "ttypescript": "^1.5.10",
     "typescript": "^3.7.5",
-    "yargs": "^15.1.0"
+    "yargs": "^15.1.0",
+    "improved-yarn-audit": "^2.2.1"
   },
   "resolutions": {
     "**/**/acorn": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,6 +4393,11 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
+improved-yarn-audit@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/improved-yarn-audit/-/improved-yarn-audit-2.2.1.tgz#6d3d5eedc31eb9c808f244931923fff7ca8a4e42"
+  integrity sha512-jfyHpHSoyKk4/xm0UULAOO32i0Q9YiHSZodZ0OIS9YMtl+idgZpmpcKrtnuAfG7VNp6KsfUv0c0mV070z8DrVQ==
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
The issue is impacting millions (literally) of packages, but it's unlikely to be fixed soon. We are likely not impacted directly, but it still fails the audit. I prefer to silence this specific advisory and keep an eye on the developments in the meanwhile.

Run only on prod dependencies since producing a json for *all* dependencies fails. It creates a huge jSON and errors with `ERROR: Unable to parse yarn audit output: SyntaxError: Unexpected end of JSON input`
